### PR TITLE
Fix depreciation warning for fetch_params/2

### DIFF
--- a/lib/trailing_format_plug.ex
+++ b/lib/trailing_format_plug.ex
@@ -10,7 +10,7 @@ defmodule TrailingFormatPlug do
         new_path       = fragments |> Enum.reverse |> Enum.join(".")
         path_fragments = List.replace_at conn.path_info, -1, new_path
         params         =
-          Plug.Conn.fetch_params(conn).params
+          Plug.Conn.fetch_query_params(conn).params
           |> Dict.put("format", format)
         %{conn | path_info: path_fragments, params: params}
     end


### PR DESCRIPTION
`warning: fetch_params/2 is deprecated, please use fetch_query_params/2 instead`
