### PR TITLE
Change format to _format. Support empty path_info. Closes #8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: elixir
 elixir: 1.0.0
 otp_release:
-  - 17.0
+  - 17.4

--- a/README.md
+++ b/README.md
@@ -9,25 +9,25 @@ Add the `trailing_format_plug` dependency to your `mix.exs` as follows:
 ```elixir
 def deps do
   #  ...
-  {:trailing_format_plug, "~> 0.0.4"}
+  {:trailing_format_plug, "~> 0.0.5"}
   # ...
 end
 ```
 
 If you are using phoenix:
 
-Add the plug to the `:before` pipeline in your router.ex:
+Add the plug to your endpoint.ex file:
 
 ```elixir
-defmodule Djay.Router do
-  use Phoenix.Router
-
-  pipeline :before do
-    plug TrailingFormatPlug
-    plug :super
-  end
+defmodule MyProject.Endpoint do
+  # ...
+  plug TrailingFormatPlug   # add this
+  plug Plug.RequestId
+  plug Plug.Logger
+  # ...
 end
 ```
+Add the plug to the `:before` pipeline in your router.ex:
 
 ## License
 

--- a/lib/trailing_format_plug.ex
+++ b/lib/trailing_format_plug.ex
@@ -3,6 +3,7 @@ defmodule TrailingFormatPlug do
 
   def init(options), do: options
 
+  def call(%{path_info: []} = conn, _opts), do: conn
   def call(conn, _opts) do
     conn.path_info |> List.last |> String.split(".") |> Enum.reverse |> case do
       [ _ ] -> conn
@@ -11,7 +12,7 @@ defmodule TrailingFormatPlug do
         path_fragments = List.replace_at conn.path_info, -1, new_path
         params         =
           Plug.Conn.fetch_query_params(conn).params
-          |> Dict.put("format", format)
+          |> Dict.put("_format", format)
         %{conn | path_info: path_fragments, query_params: params, params: params}
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule TrailingFormatPlug.Mixfile do
   def project do
     [
       app: :trailing_format_plug,
-      version: "0.0.4",
+      version: "0.0.5",
       elixir: ">= 1.0.0",
       deps: deps,
       package: [

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,4 @@
-%{"cowboy": {:hex, :cowboy, "1.0.0"},
-  "cowlib": {:hex, :cowlib, "1.0.1"},
-  "plug": {:hex, :plug, "0.13.0"},
-  "ranch": {:hex, :ranch, "1.0.0"}}
+%{"cowboy": {:hex, :cowboy, "1.0.0", "d0b46a5e5f971c5543eb46f86fe76b9add567d12fb5262a852b8f27c64c0555d", [:make, :rebar], [{:cowlib, "~> 1.0.0", [hex: :cowlib, optional: false]}, {:ranch, "~> 1.0", [hex: :ranch, optional: false]}]},
+  "cowlib": {:hex, :cowlib, "1.0.1", "175a633c472058bbeb1b238a6409766a48b52b43b7b687ed70f03cf6e854b7d9", [:make], []},
+  "plug": {:hex, :plug, "0.13.0", "2fed890715c53a2e47a8c410fac5b198770aa7abe996cf85cd496c3492dc4bc8", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}]},
+  "ranch": {:hex, :ranch, "1.0.0", "e3ac054e4265de77e2d2696dd7e1d6a67b7525aade13ba10c860e7f499a0d433", [:make], []}}

--- a/test/trailing_format_plug_test.exs
+++ b/test/trailing_format_plug_test.exs
@@ -27,6 +27,17 @@ defmodule TrailingFormatPlugTest do
 
     conn = TrailingFormatPlug.call(conn, @opts)
 
-    assert conn.params["format"] == "json"
+    assert conn.params["_format"] == "json"
+  end
+
+  test "plug supports empty path_info" do
+    conn =
+      conn(:get, "/")
+      |> Plug.Conn.fetch_query_params
+
+    conn = TrailingFormatPlug.call(conn, @opts)
+
+    assert conn.path_info == []
+    refute conn.params["_format"]
   end
 end


### PR DESCRIPTION
Support get "/" by matching on `%{path_info: []}`. Change params["format"] = "json" to params["_format"] to match Phoenix change. Added and updated unit tests.