### PR TITLE
strip format from parameter

### DIFF
--- a/lib/trailing_format_plug.ex
+++ b/lib/trailing_format_plug.ex
@@ -13,6 +13,7 @@ defmodule TrailingFormatPlug do
         params         =
           Plug.Conn.fetch_query_params(conn).params
           |> Dict.put("_format", format)
+          |> Dict.put(new_path, new_path)
         %{conn | path_info: path_fragments, query_params: params, params: params}
     end
   end

--- a/test/trailing_format_plug_test.exs
+++ b/test/trailing_format_plug_test.exs
@@ -26,8 +26,20 @@ defmodule TrailingFormatPlugTest do
       |> Plug.Conn.fetch_query_params
 
     conn = TrailingFormatPlug.call(conn, @opts)
-
     assert conn.params["_format"] == "json"
+  end
+
+  test "plug removes .json from param" do
+    params = Map.put(%{}, "bar", "bar.json")
+
+    conn =
+      conn(:get, "/foo/bar.json")
+      |> Plug.Conn.fetch_query_params
+      |> Map.put(:params, params)
+
+    conn = TrailingFormatPlug.call(conn, @opts)
+    assert conn.params["_format"] == "json"
+    assert conn.params["bar"] == "bar"
   end
 
   test "plug supports empty path_info" do


### PR DESCRIPTION
In the case where the last item in the path_info is a parameter, we would want to strip the format type off of this parameter.

e.g. /api/:sport

When requesting /api/:hockey.json, we would want to sport parameter to be "hockey" and not "hockey.json".