### PR TITLE
strip format from parameter

### DIFF
--- a/lib/trailing_format_plug.ex
+++ b/lib/trailing_format_plug.ex
@@ -12,8 +12,18 @@ defmodule TrailingFormatPlug do
         path_fragments = List.replace_at conn.path_info, -1, new_path
         params         =
           Plug.Conn.fetch_query_params(conn).params
+          |> update_params(new_path, format)
           |> Dict.put("_format", format)
         %{conn | path_info: path_fragments, query_params: params, params: params}
+    end
+  end
+
+  defp update_params(params, new_path, format) do
+    params
+    |> Enum.find(fn {key, val} -> val == "#{new_path}.#{format}" end)
+    |> case do
+      {key, _} -> Map.put(params, key, new_path)
+      _ -> params
     end
   end
 end

--- a/test/trailing_format_plug_test.exs
+++ b/test/trailing_format_plug_test.exs
@@ -26,8 +26,20 @@ defmodule TrailingFormatPlugTest do
       |> Plug.Conn.fetch_query_params
 
     conn = TrailingFormatPlug.call(conn, @opts)
-
     assert conn.params["_format"] == "json"
+  end
+
+  test "plug removes .json from param" do
+    params = Map.put(%{}, "sport", "hockey.json")
+
+    conn =
+      conn(:get, "/api/hockey.json")
+      |> Plug.Conn.fetch_query_params
+      |> Map.put(:params, params)
+
+    conn = TrailingFormatPlug.call(conn, @opts)
+    assert conn.params["_format"] == "json"
+    assert conn.params["sport"] == "hockey"
   end
 
   test "plug supports empty path_info" do


### PR DESCRIPTION
In the case where the last item in the path_info is a parameter, we would want to strip the format type off of this parameter.

e.g. /api/:sport

When requesting /api/:hockey.json, we would want to sport parameter to be "hockey" and not "hockey.json".