### PR TITLE
Pass in accepted formats via options

### DIFF
--- a/lib/trailing_format_plug.ex
+++ b/lib/trailing_format_plug.ex
@@ -12,8 +12,18 @@ defmodule TrailingFormatPlug do
         path_fragments = List.replace_at conn.path_info, -1, new_path
         params         =
           Plug.Conn.fetch_query_params(conn).params
+          |> update_params(new_path, format)
           |> Dict.put("_format", format)
         %{conn | path_info: path_fragments, query_params: params, params: params}
+    end
+  end
+
+  defp update_params(params, new_path, format) do
+    params
+    |> Enum.find(fn {key, val} -> val == "#{new_path}.#{format}" end)
+    |> case do
+      {key, _} -> Map.put(params, key, new_path)
+      _ -> params
     end
   end
 end

--- a/test/trailing_format_plug_test.exs
+++ b/test/trailing_format_plug_test.exs
@@ -26,8 +26,20 @@ defmodule TrailingFormatPlugTest do
       |> Plug.Conn.fetch_query_params
 
     conn = TrailingFormatPlug.call(conn, @opts)
-
     assert conn.params["_format"] == "json"
+  end
+
+  test "plug removes .json from param" do
+    params = Map.put(%{}, "sport", "hockey.json")
+
+    conn =
+      conn(:get, "/api/hockey.json")
+      |> Plug.Conn.fetch_query_params
+      |> Map.put(:params, params)
+
+    conn = TrailingFormatPlug.call(conn, @opts)
+    assert conn.params["_format"] == "json"
+    assert conn.params["sport"] == "hockey"
   end
 
   test "plug supports empty path_info" do

--- a/test/trailing_format_plug_test.exs
+++ b/test/trailing_format_plug_test.exs
@@ -2,7 +2,15 @@ defmodule TrailingFormatPlugTest do
   use ExUnit.Case, async: true
   use Plug.Test
 
-  @opts TrailingFormatPlug.init([])
+  @opts TrailingFormatPlug.init(["json"])
+
+  test "plug ignores formats that are not passed as options" do
+    conn = conn(:get, "/foo/bar.html")
+
+    conn = TrailingFormatPlug.call(conn, @opts)
+
+    assert conn.path_info == ["foo", "bar.html"]
+  end
 
   test "plug removes trailing format" do
     conn = conn(:get, "/foo/bar.json")

--- a/test/trailing_format_plug_test.exs
+++ b/test/trailing_format_plug_test.exs
@@ -2,62 +2,75 @@ defmodule TrailingFormatPlugTest do
   use ExUnit.Case, async: true
   use Plug.Test
 
+  @no_opts TrailingFormatPlug.init([])
   @opts TrailingFormatPlug.init(["json"])
 
-  test "plug ignores formats that are not passed as options" do
-    conn = conn(:get, "/foo/bar.html")
+  describe "when formats are passed as options" do
+    test "plug ignores formats that are not passed as options" do
+      conn = conn(:get, "/foo/bar.html")
 
-    conn = TrailingFormatPlug.call(conn, @opts)
+      conn = TrailingFormatPlug.call(conn, @opts)
 
-    assert conn.path_info == ["foo", "bar.html"]
+      assert conn.path_info == ["foo", "bar.html"]
+    end
+
+    test "plug removes trailing format included in options" do
+      conn = conn(:get, "/foo/bar.json")
+
+      conn = TrailingFormatPlug.call(conn, @opts)
+
+      assert conn.path_info == ["foo", "bar"]
+    end
   end
 
-  test "plug removes trailing format" do
-    conn = conn(:get, "/foo/bar.json")
+  describe "when options are not passed" do
+    test "plug removes trailing format" do
+      conn = conn(:get, "/foo/bar.json")
 
-    conn = TrailingFormatPlug.call(conn, @opts)
+      conn = TrailingFormatPlug.call(conn, @no_opts)
 
-    assert conn.path_info == ["foo", "bar"]
-  end
+      assert conn.path_info == ["foo", "bar"]
+    end
 
-  test "plug does nothing without trailing format" do
-    conn = conn(:get, "/foo/bar")
+    test "plug does nothing without trailing format" do
+      conn = conn(:get, "/foo/bar")
 
-    conn = TrailingFormatPlug.call(conn, @opts)
+      conn = TrailingFormatPlug.call(conn, @no_opts)
 
-    assert conn.path_info == ["foo", "bar"]
-  end
+      assert conn.path_info == ["foo", "bar"]
+    end
 
-  test "plug adds format to conn.params" do
-    conn =
-      conn(:get, "/foo/bar.json")
-      |> Plug.Conn.fetch_query_params
+    test "plug adds format to conn.params" do
+      conn =
+        conn(:get, "/foo/bar.json")
+        |> Plug.Conn.fetch_query_params
 
-    conn = TrailingFormatPlug.call(conn, @opts)
-    assert conn.params["_format"] == "json"
-  end
+      conn = TrailingFormatPlug.call(conn, @no_opts)
+      assert conn.params["_format"] == "json"
+    end
 
-  test "plug removes .json from param" do
-    params = Map.put(%{}, "sport", "hockey.json")
+    test "plug removes .json from param" do
+      params = Map.put(%{}, "sport", "hockey.json")
 
-    conn =
-      conn(:get, "/api/hockey.json")
-      |> Plug.Conn.fetch_query_params
-      |> Map.put(:params, params)
+      conn =
+        conn(:get, "/api/hockey.json")
+        |> Plug.Conn.fetch_query_params
+        |> Map.put(:params, params)
 
-    conn = TrailingFormatPlug.call(conn, @opts)
-    assert conn.params["_format"] == "json"
-    assert conn.params["sport"] == "hockey"
-  end
+      conn = TrailingFormatPlug.call(conn, @no_opts)
+      assert conn.params["_format"] == "json"
+      assert conn.params["sport"] == "hockey"
+    end
 
-  test "plug supports empty path_info" do
-    conn =
-      conn(:get, "/")
-      |> Plug.Conn.fetch_query_params
+    test "plug supports empty path_info" do
+      conn =
+        conn(:get, "/")
+        |> Plug.Conn.fetch_query_params
 
-    conn = TrailingFormatPlug.call(conn, @opts)
+      conn = TrailingFormatPlug.call(conn, @no_opts)
 
-    assert conn.path_info == []
-    refute conn.params["_format"]
+      assert conn.path_info == []
+      refute conn.params["_format"]
+    end
   end
 end


### PR DESCRIPTION
I would like to use options to pass in the accepted format types.  For instance, if I have a json endpoint, I would like to allow /api/example.json as a valid request.  However, I would not want /api/example.html or any other extension to hit my json endpoint.

This pull request first checks to see if there are any options.  If not, then all formats are accepted and stripped of their format.  

If options are passed, it checks if the format of the request matches any of the formats in the options.  The requests that do match will have their formats stripped.  Requests that do not match are ignored and the conn is simply returned.