### PR TITLE
Ignore minor versions in cowboy dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,7 @@ defmodule TrailingFormatPlug.Mixfile do
 
   defp deps do
     [
-      {:cowboy, "~> 1.0.0"},
+      {:cowboy, "~> 1.0"},
       {:plug, "> 0.12.0"},
 
       {:ex_doc, "~> 0.14.3", only: [:dev]}


### PR DESCRIPTION
The latest version of cowboy is in the 1.1.x range - it's reasonable to ignore patch releases in the dependencies for this plugin.